### PR TITLE
Clear the terminal screen before starting PaleRa1n

### DIFF
--- a/palera1n.sh
+++ b/palera1n.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-
+printf "\033c"
 mkdir -p logs
 set -e
 


### PR DESCRIPTION
I'd say it's much easier this way for the user to understand what output comes from PaleRa1n and it's easier to copy and paste logs in case of bugs. Feel free to dismiss.