### PR TITLE
fix "failed to read lastArgFile"

### DIFF
--- a/palera1n.sh
+++ b/palera1n.sh
@@ -751,7 +751,7 @@ if [ ! -f boot-"$deviceid"/ibot.img4 ]; then
     mkdir boot-"$deviceid"
 
     echo "[*] Converting blob"
-    "$dir"/img4tool -e -s $(pwd)/blobs/"$deviceid"-"$version".shsh2 -m work/IM4M
+    "$dir"/img4tool -e -s "$(pwd)"/blobs/"$deviceid"-"$version".shsh2 -m work/IM4M
     cd work
 
     echo "[*] Downloading BuildManifest"


### PR DESCRIPTION
if the palera1n directory's path had spaces in it, img4tool would not be able to read the blob. adding quotes around the $(pwd) call fixes this.