### PR TITLE
Adds to supports iPod touch 7th gen.

### DIFF
--- a/palera1n.sh
+++ b/palera1n.sh
@@ -189,11 +189,7 @@ get_device_mode() {
     local usbserials=""
     for apple in $apples; do
         case "$apple" in
-            12ab)
-            device_mode=normal
-            device_count=$((device_count+1))
-            ;;
-            12a8)
+            12a8|12ab)
             device_mode=normal
             device_count=$((device_count+1))
             ;;

--- a/palera1n.sh
+++ b/palera1n.sh
@@ -189,7 +189,7 @@ get_device_mode() {
     local usbserials=""
     for apple in $apples; do
         case "$apple" in
-            12a8|12ab)
+            12a8|12aa|12ab)
             device_mode=normal
             device_count=$((device_count+1))
             ;;


### PR DESCRIPTION
iPod touch 7th gen.'s normal mode product id is 0x12aa, which is not in palera1n.sh `get_device_mode()`.