### PR TITLE
README.md: Correct dora2ios to dora2-ios in Credits

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,6 @@ If you want to make a rootless repo, use the official [palera1n repo](https://gi
 - [Cryptic](https://github.com/Cryptiiiic) for [iBoot64Patcher](https://github.com/Cryptiiiic/iBoot64Patcher) fork, and [liboffsetfinder64](https://github.com/Cryptiiiic/liboffsetfinder64) fork
 - [libimobiledevice](https://github.com/libimobiledevice) for several tools used in this project (irecovery, ideviceenterrecovery etc), and [nikias](https://github.com/nikias) for keeping it up to date
 - [Nick Chan](https://github.com/asdfugil) general help with patches and iBoot payload stuff
-- [Dora](https://github.com/dora2ios) for iBoot payload and iBootpatcher2
+- [Dora](https://github.com/dora2-iOS) for iBoot payload and iBootpatcher2
 - [Sam Bingner](https://github.com/sbingner) for [Substitute](https://github.com/sbingner/substitute)
 - [Serena](https://github.com/SerenaKit) for helping with boot ramdisk.


### PR DESCRIPTION
I think the link is wrong