### PR TITLE
Use proper log dir

### DIFF
--- a/palera1n.sh
+++ b/palera1n.sh
@@ -13,7 +13,8 @@ echo "[*] Command ran:`if [ $EUID = 0 ]; then echo " sudo"; fi` ./palera1n.sh $@
 ipsw="" # IF YOU WERE TOLD TO PUT A CUSTOM IPSW URL, PUT IT HERE. YOU CAN FIND THEM ON https://appledb.dev
 version="1.2.0"
 os=$(uname)
-dir="$(pwd)/binaries/$os"
+rootDir="$(pwd)"
+dir="$rootDir/binaries/$os"
 commit=$(git rev-parse --short HEAD)
 branch=$(git rev-parse --abbrev-ref HEAD)
 
@@ -158,11 +159,11 @@ _exit_handler() {
     [ $? -eq 0 ] && exit
     echo "[-] An error occurred"
 
-    cd logs
+    pushd "$rootDir/logs"
     for file in *.log; do
         mv "$file" FAIL_${file}
     done
-    cd ..
+	 popd
 
     echo "[*] A failure log has been made. If you're going to make a GitHub issue, please attach the latest log."
 }


### PR DESCRIPTION
Depending on where the script fails, the logs might not be in `working directory/logs` but the script assumes it is. I came across this myself when it crashed and couldn't find the `logs` dir.
This fixes the issue by setting a variable at the start and then reading that upon trying to find the `logs` dir. I also used `pushd` and `popd` as opposed to `cd` and `cd ..` as that would put the script in the root dir, which, again is not necesairily where it came from.