### PR TITLE
Check for disk when restoring rootfs too

### DIFF
--- a/palera1n.sh
+++ b/palera1n.sh
@@ -563,7 +563,7 @@ if [ ! -f blobs/"$deviceid"-"$version".der ]; then
 
     touch .rd_in_progress
     
-    if [ "$tweaks" = "1" ]; then
+    if [ "$tweaks" = "1" ] || [ "$restorerootfs" = "1" ]; then
         echo "[*] Testing for baseband presence"
         if [ "$(remote_cmd "/usr/bin/mgask HasBaseband | grep -E 'true|false'")" = "true" ] && [[ "${cpid}" == *"0x700"* ]]; then
             disk=7


### PR DESCRIPTION
Just makes restorerootfs work if not used with --tweaks on semi-tethered palera1n