### PR TITLE
Fix cannot find iproxy to kill

### DIFF
--- a/palera1n.sh
+++ b/palera1n.sh
@@ -286,7 +286,8 @@ _kill_if_running() {
         sudo killall $1
     else
         if (pgrep -x "$1" &> /dev/null > /dev/null); then
-            killall $1
+            killall -q $1
+            sudo killall -q $1
         fi
     fi
 }


### PR DESCRIPTION
For some devices:
```
[*] Device entered DFU!
+ sleep 2
+ '[' -f blobs/iPhone10,3-15.7.1.der ']'
+ '[' '!' -f blobs/iPhone10,3-15.7.1.der ']'
+ mkdir -p blobs
+ _kill_if_running iproxy
+ pgrep -u root -xf iproxy
+ pgrep -x iproxy
+ killall iproxy
No matching processes belonging to you were found
+ _exit_handler
+ '[' 1 -eq 0 ']'
+ echo '[-] An error occurred'
[-] An error occurred
+ '[' -d logs ']'
+ cd logs
+ mv 02:27:39-2022-12-28-Darwin-22.2.0.log FAIL_02:27:39-2022-12-28-Darwin-22.2.0.log
+ cd ..
+ echo '[*] A failure log has been made. If you'\''re going ask for help, please attach the latest log.'
[*] A failure log has been made. If you're going ask for help, please attach the latest log.
MacBook-Pro:palera1n RCM$ 
```
After using:
```
sudo killall iproxy
```
the problem solved.