### PR TITLE
Automatically load launch daemons on startup

### DIFF
--- a/other/rootfs/jbin/post.sh
+++ b/other/rootfs/jbin/post.sh
@@ -7,5 +7,8 @@ $binpack/usr/bin/uicache -p /jbin/loader.app
 # respring
 $binpack/usr/bin/killall -9 SpringBoard
 
+# load launch daemons
+/usr/bin/launchctl bootstrap system /Library/LaunchDaemons
+
 echo "[post.sh] done"
 exit


### PR DESCRIPTION
Added an entry to the post.sh script so that launch daemons will automatically load on startup.

This is something that I find very useful because you won't need to open the loader app and press the button to load the launch daemons every time you jailbreak.