### PR TITLE
dfuhelper: check if device is already in DFU mode

### DIFF
--- a/palera1n.sh
+++ b/palera1n.sh
@@ -268,6 +268,11 @@ _wait() {
 
 dfuhelper_first_try=true
 _dfuhelper() {
+    if [ "$(get_device_mode)" = "dfu" ]; then
+        echo "[*] Device is already in DFU"
+        return
+    fi
+
     local step_one;
     deviceid=$( [ -z "$deviceid" ] && _info normal ProductType || echo $deviceid )
     if [[ "$1" = 0x801* && "$deviceid" != *"iPad"* ]]; then


### PR DESCRIPTION
If the user runs it manually, or in some cases while running the script, the device may be already in DFU, so don't wait around in that case.