### PR TITLE
chore: elaborate on ignoring non arm64 device

### DIFF
--- a/src/dfuhelper.c
+++ b/src/dfuhelper.c
@@ -56,6 +56,7 @@ int connected_normal_mode(const usbmuxd_device_info_t *usbmuxd_device) {
 	if (strcmp(dev.CPUArchitecture, "arm64")) {
 		devinfo_free(&dev);
 		LOG(LOG_WARNING, "Ignoring non-arm64 device...");
+		LOG(LOG_WARNING, "palera1n doesn't and never will work on A12+ (arm64e)");
 		return -1;
 	}
 	if (!strncmp(dev.productType, "iPhone10,", strlen("iPhone10,"))) {


### PR DESCRIPTION
people don't read.
to save people from asking in the Discord what "Ignoring non-arm64 device.." means, elaborate.