### PR TITLE
Improve non-arm64 detection

### DIFF
--- a/src/dfuhelper.c
+++ b/src/dfuhelper.c
@@ -172,6 +172,12 @@ void* connected_recovery_mode(struct irecv_device_info* info) {
 }
 
 void* connected_dfu_mode(struct irecv_device_info* info) {
+	if (!cpid_is_arm64(info->cpid)) {
+		LOG(LOG_WARNING, "Ignoring non-arm64 device...");
+		LOG(LOG_WARNING, "palera1n doesn't and never will work on A12+ (arm64e)");
+		return NULL;
+	}
+
 	if (get_ecid_wait_for_dfu() == info->ecid) {
 		set_ecid_wait_for_dfu(0);
 		puts("");

--- a/src/dfuhelper.c
+++ b/src/dfuhelper.c
@@ -129,6 +129,7 @@ void* connected_recovery_mode(struct irecv_device_info* info) {
 	info = NULL;
 	if (!cpid_is_arm64(cpid)) {
 		LOG(LOG_WARNING, "Ignoring non-arm64 device...");
+		LOG(LOG_WARNING, "palera1n doesn't and never will work on A12+ (arm64e)");
 		return NULL;
 	}
 	sleep(1);

--- a/src/dfuhelper.c
+++ b/src/dfuhelper.c
@@ -61,7 +61,7 @@ int connected_normal_mode(const usbmuxd_device_info_t *usbmuxd_device) {
 		LOG(LOG_ERROR, "Unable to get device information");
 		return 0;
 	}
-	if (strncmp(dev.CPUArchitecture, "arm64", strlen("arm64"))) {
+	if (strcmp(dev.CPUArchitecture, "arm64")) {
 		devinfo_free(&dev);
 		LOG(LOG_WARNING, "Ignoring non-arm64 device...");
 		LOG(LOG_WARNING, "palera1n doesn't and never will work on A12+ (arm64e)");


### PR DESCRIPTION
This PR fixes non-arm64 (e.g. arm64e) device detection in normal mode having been broken by a recent cleanup commit, unifies the warning messages, and adds a check for DFU mode as well.