### PR TITLE
Change palera1n-c to palera1n

### DIFF
--- a/src/credits.c
+++ b/src/credits.c
@@ -11,7 +11,7 @@
 #define U (
 #define B stderr
 #define L ,
-#define E "# == palera1n-c == \n#\n"
+#define E "# == palera1n == \n#\n"
 #define M "# Made by: Nick Chan, " THE_PLUSH ", Samara, Nebula, staturnz, " BAKERAIN_DEVELOPE_R " \n#\n"
 #define A "# Thanks to: pythonplayer123, llsc12, Mineek, tihmstar, nikias\n"
 #define K "# (libimobiledevice), checkra1n team (Siguza, axi0mx, littlelailo\n"


### PR DESCRIPTION
Wasn't 2.0.0 only called palera1n-c when legacy was still being used?