### PR TITLE
Harden logging and buffer safety

### DIFF
--- a/src/exec_checkra1n.c
+++ b/src/exec_checkra1n.c
@@ -155,8 +155,8 @@ setenv_ra1n:
 	} else {
 		strncat(args, "R", 0xf);
 	}
-	LOG(LOG_VERBOSE5, args);
-	if (pongo_path != NULL) LOG(LOG_VERBOSE5, pongo_path);
+	LOG(LOG_VERBOSE5, "%s", args);
+	if (pongo_path != NULL) LOG(LOG_VERBOSE5, "%s", pongo_path);
 	pid_t pid;
 	posix_spawn_file_actions_t action;
     posix_spawn_file_actions_init(&action);

--- a/src/log.c
+++ b/src/log.c
@@ -34,6 +34,7 @@ int p1_log(log_level_t loglevel, const char *fname, int lineno, const char *fxna
 		&& !tui_started
 #endif
 ) fprintf(stderr, "p1_log: hid log with high log level (%d < %d)\n", verbose, loglevel - 3);
+		va_end(args);
         return 0;
     }
 	switch (loglevel) {

--- a/src/main.c
+++ b/src/main.c
@@ -86,7 +86,7 @@ bool tui_started = false;
 
 #ifdef USE_LIBUSB
 void log_cb(libusb_context *ctx, enum libusb_log_level level, const char *str) {
-    LOG(level + 0, str);
+    LOG(level + 0, "%s", str);
 }
 #endif
 

--- a/src/tui_devhelper.c
+++ b/src/tui_devhelper.c
@@ -62,7 +62,7 @@ static void* tui_disconnected_dfu_mode(struct irecv_device_info* info) {
 
 static int tui_connected_normal_mode(const usbmuxd_device_info_t *usbmuxd_device) {
     struct tui_connected_device *tui_dev = malloc(sizeof(struct tui_connected_device));
-    strcpy(tui_dev->udid, usbmuxd_device->udid);
+    snprintf(tui_dev->udid, sizeof(tui_dev->udid), "%s", usbmuxd_device->udid);
     tui_dev->next = tui_connected_devices;
     tui_dev->mode = TUI_DEVICE_MODE_NORMAL;
     tui_connected_devices = tui_dev;
@@ -82,7 +82,7 @@ static int tui_connected_normal_mode(const usbmuxd_device_info_t *usbmuxd_device
     } else {
         tui_dev->arm64 = true;
     }
-    sprintf(tui_dev->version, "%s", dev.productVersion);
+    snprintf(tui_dev->version, sizeof(tui_dev->version), "%s", dev.productVersion);
 	if (!strncmp(dev.productType, "iPhone10,", strlen("iPhone10,"))) {
 		tui_dev->requires_passcode_disabled = true;
 		unsigned char passcode_state = 0;

--- a/src/tui_screen_options.c
+++ b/src/tui_screen_options.c
@@ -186,7 +186,11 @@ tui_screen_t tui_screen_options(void) {
                 break;
             case TUI_INPUT_SELECT:
                 if (tui_options_is_editing_boot_args && tui_last_key == ' ' && tui_options_boot_args[strlen(tui_options_boot_args)] == '\x00') {
-                    int len = strlen(tui_options_boot_args);
+                    size_t max_len = sizeof(tui_options_boot_args) - 1;
+                    size_t len = strlen(tui_options_boot_args);
+                    if (len >= max_len) {
+                        break;
+                    }
                     tui_options_boot_args[len] = ' ';
                     tui_options_boot_args[len + 1] = '\x00';
                     tui_options_boot_args_cursor++;
@@ -304,7 +308,11 @@ tui_screen_t tui_screen_options(void) {
                 break;
             case TUI_INPUT_NONE:
                 if (tui_options_is_editing_boot_args && tui_options_boot_args[strlen(tui_options_boot_args)] == '\x00') {
-                    int len = strlen(tui_options_boot_args);
+                    size_t max_len = sizeof(tui_options_boot_args) - 1;
+                    size_t len = strlen(tui_options_boot_args);
+                    if (len >= max_len) {
+                        break;
+                    }
                     memmove(tui_options_boot_args + tui_options_boot_args_cursor + 1, tui_options_boot_args + tui_options_boot_args_cursor, strlen(tui_options_boot_args) - tui_options_boot_args_cursor);
                     tui_options_boot_args[tui_options_boot_args_cursor] = tui_last_key;
                     tui_options_boot_args[len + 1] = '\x00';


### PR DESCRIPTION
This PR improves code safety by hardening string handling and logging. It notably adds bounds checks to stop TUI boot‑args input from overflowing the buffer.