### PR TITLE
ci: upload build artifacts with easySFTP

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,16 +45,17 @@ jobs:
 
       - name: Upload artifact
         if: ${{ github.event_name != 'pull_request' }}
-        uses: wangyucode/sftp-upload-action@v3
+        uses: eiserv/easySFTP@v3
         with:
           host: ${{ secrets.NICKCHAN_FTP_HOST }}
           port: ${{ secrets.NICKCHAN_FTP_PORT }}
           username: palera1n
           password: ${{ secrets.NICKCHAN_FTP_PASS }}
-          forceUpload: true
-          dryRun: false
-          localDir: 'ready/'
-          remoteDir: "/palera1n/artifacts/c-rewrite/${{ steps.branch-name.outputs.ref_branch || github.ref_name }}/${{ github.run_number }}"
+          source: 'ready/'
+          target: "/palera1n/artifacts/c-rewrite/${{ steps.branch-name.outputs.ref_branch || github.ref_name }}/${{ github.run_number }}"
+          # Same trust model as before. Once a NICKCHAN_KNOWN_HOSTS secret
+          # exists: known-hosts: ${{ secrets.NICKCHAN_KNOWN_HOSTS }}
+          allow-any-host-key: true
 
   build-darwin:
     strategy:
@@ -336,16 +337,17 @@ jobs:
 
       - name: Upload artifact
         if: ${{ github.event_name != 'pull_request' }}
-        uses: wangyucode/sftp-upload-action@v3
+        uses: eiserv/easySFTP@v3
         with:
           host: ${{ secrets.NICKCHAN_FTP_HOST }}
           port: ${{ secrets.NICKCHAN_FTP_PORT }}
           username: palera1n
           password: ${{ secrets.NICKCHAN_FTP_PASS }}
-          forceUpload: true
-          dryRun: false
-          localDir: 'ready/'
-          remoteDir: "/palera1n/artifacts/c-rewrite/${{ steps.branch-name.outputs.ref_branch || github.ref_name }}/${{ github.run_number }}"
+          source: 'ready/'
+          target: "/palera1n/artifacts/c-rewrite/${{ steps.branch-name.outputs.ref_branch || github.ref_name }}/${{ github.run_number }}"
+          # Same trust model as before. Once a NICKCHAN_KNOWN_HOSTS secret
+          # exists: known-hosts: ${{ secrets.NICKCHAN_KNOWN_HOSTS }}
+          allow-any-host-key: true
 
       - name: Upload ${{ matrix.os }} thin ${{ matrix.arch }} build
         if: ${{ github.event_name != 'pull_request' }}
@@ -508,16 +510,17 @@ jobs:
 
       - name: Upload artifact
         if: ${{ github.event_name != 'pull_request' }}
-        uses: wangyucode/sftp-upload-action@v3
+        uses: eiserv/easySFTP@v3
         with:
           host: ${{ secrets.NICKCHAN_FTP_HOST }}
           port: ${{ secrets.NICKCHAN_FTP_PORT }}
           username: palera1n
           password: ${{ secrets.NICKCHAN_FTP_PASS }}
-          forceUpload: true
-          dryRun: false
-          localDir: 'ready/'
-          remoteDir: "/palera1n/artifacts/c-rewrite/${{ steps.branch-name.outputs.ref_branch || github.ref_name }}/${{ github.run_number }}"
+          source: 'ready/'
+          target: "/palera1n/artifacts/c-rewrite/${{ steps.branch-name.outputs.ref_branch || github.ref_name }}/${{ github.run_number }}"
+          # Same trust model as before. Once a NICKCHAN_KNOWN_HOSTS secret
+          # exists: known-hosts: ${{ secrets.NICKCHAN_KNOWN_HOSTS }}
+          allow-any-host-key: true
 
   build-Linux:
     strategy:
@@ -848,29 +851,31 @@ jobs:
 
       - name: Upload artifact
         if: ${{ github.event_name != 'pull_request' }}
-        uses: wangyucode/sftp-upload-action@v3
+        uses: eiserv/easySFTP@v3
         with:
           host: ${{ secrets.NICKCHAN_FTP_HOST }}
           port: ${{ secrets.NICKCHAN_FTP_PORT }}
           username: palera1n
           password: ${{ secrets.NICKCHAN_FTP_PASS }}
-          forceUpload: true
-          dryRun: false
-          localDir: 'ready/'
-          remoteDir: "/palera1n/artifacts/c-rewrite/${{ steps.branch-name.outputs.ref_branch || github.ref_name }}/${{ github.run_number }}"
+          source: 'ready/'
+          target: "/palera1n/artifacts/c-rewrite/${{ steps.branch-name.outputs.ref_branch || github.ref_name }}/${{ github.run_number }}"
+          # Same trust model as before. Once a NICKCHAN_KNOWN_HOSTS secret
+          # exists: known-hosts: ${{ secrets.NICKCHAN_KNOWN_HOSTS }}
+          allow-any-host-key: true
 
       - name: Upload usbmuxd artifact
         if: ${{ github.event_name != 'pull_request' }}
-        uses: wangyucode/sftp-upload-action@v3
+        uses: eiserv/easySFTP@v3
         with:
           host: ${{ secrets.NICKCHAN_FTP_HOST }}
           port: ${{ secrets.NICKCHAN_FTP_PORT }}
           username: palera1n
           password: ${{ secrets.NICKCHAN_FTP_PASS }}
-          forceUpload: true
-          dryRun: false
-          localDir: 'usbmuxd-static/'
-          remoteDir: "/palera1n/artifacts/usbmuxd-static"
+          source: 'usbmuxd-static/'
+          target: "/palera1n/artifacts/usbmuxd-static"
+          # Same trust model as before. Once a NICKCHAN_KNOWN_HOSTS secret
+          # exists: known-hosts: ${{ secrets.NICKCHAN_KNOWN_HOSTS }}
+          allow-any-host-key: true
 
       - name: Generate cached sysroot archive
         if: steps.sysroot_cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
Disclosure up front: I maintain easySFTP, so this PR proposes my own action. Close it without ceremony if you would rather not switch.

All five artifact upload steps in `build.yml` move from `wangyucode/sftp-upload-action@v3` to `eiserv/easySFTP@v3`. Secret names are unchanged (`NICKCHAN_FTP_HOST`, `NICKCHAN_FTP_PORT`, `NICKCHAN_FTP_PASS`), so nothing needs configuring in repo settings before merging.

## What changes

| before | after | note |
| --- | --- | --- |
| `localDir` | `source` | |
| `remoteDir` | `target` | missing remote directories are still created |
| `forceUpload: true` | dropped | easySFTP's default mode uploads every file, which is what `forceUpload` asked for |
| `dryRun: false` | dropped | `dry-run` already defaults to false |
| | `allow-any-host-key: true` | see below |

`host`, `port`, `username` and `password` keep their names and values.

One side effect goes away with `forceUpload`. `wangyucode/sftp-upload-action@v3` writes a `.sftp_upload_action_hashes` file into the remote directory at the end of **every** run, including runs with `forceUpload: true` where it never reads it. So today each of these directories under `static.palera.in/artifacts/` gets a JSON file listing every artifact name and its MD5, sitting next to the artifacts. easySFTP in the default mode keeps no state on the server and writes nothing but the files you gave it.

## About `allow-any-host-key: true`

easySFTP refuses to connect unless you either pin the server's host key or say explicitly that you do not want to. `wangyucode/sftp-upload-action` opens a paramiko `Transport` and connects without any host key policy, so `allow-any-host-key: true` is what keeps the current behaviour. Merging this changes your trust model in neither direction.

The upgrade is one line whenever you want it. Run

```
ssh-keyscan -p <port> <host>
```

put the output in a `NICKCHAN_KNOWN_HOSTS` secret, and replace `allow-any-host-key: true` with `known-hosts: ${{ secrets.NICKCHAN_KNOWN_HOSTS }}`. Multiple lines are accepted, so paste every key the server offers and stop caring which algorithm gets negotiated.

It is worth doing here. `NICKCHAN_FTP_PASS` is a password, and a password goes to whichever host answers on `NICKCHAN_FTP_HOST`. Anything that can redirect that connection gets write access to the directory people download palera1n builds from. Host key pinning is the cheap half of closing that.

## Why change

**Uploads are atomic per file.** The old action opens the destination path and writes into it. If a connection drops partway through, the file at that URL is truncated but still present and still has the right name, and it stays that way until something overwrites it. Given these directories are what users download builds from, that is the failure I would least want. easySFTP streams each file to a temporary sibling and renames it over the target only once the transfer fully succeeded.

**It retries.** A dropped connection is currently a failed job at the end of a long matrix build. easySFTP redials on connection level errors within a run wide retry budget and continues where it stopped. There is also a stall watchdog for the case where the server accepts the connection and then goes quiet, which a plain socket timeout does not catch.

**Less setup per run.** `wangyucode/sftp-upload-action@v3` is a composite action whose first step is `pip install -r requirements.txt`, so every one of these five steps installs paramiko (and cryptography under it) before the first byte moves, on macOS runners too. easySFTP downloads one static Go binary and verifies it against the release checksums. Nothing else is installed, and there is no interpreter or wheel resolution in the path.

**Throughput.** The old action runs 4 worker threads over channels on a single paramiko `Transport`, and each worker also MD5s the file it is about to send. easySFTP transfers files in parallel (4 by default) and additionally keeps multiple write requests in flight inside each file (16 by default), which is what actually fills the pipe for the large artifacts here rather than just overlapping small ones.

Other things that might be useful: `dry-run`, `files-uploaded` / `bytes-uploaded` / `duration-ms` step outputs, a job summary table, gitignore syntax exclude patterns, and `mode: sync` if you ever want a directory mirrored rather than added to.

Docs: https://github.com/eiserv/easySFTP

I could not test against static.palera.in, for obvious reasons. The mapping above is mechanical, the five steps were byte identical apart from `localDir` and `remoteDir`, and nothing else in `build.yml` moved. Happy to adjust anything.
